### PR TITLE
Add wrapper to wcstok

### DIFF
--- a/ANSI.c
+++ b/ANSI.c
@@ -131,6 +131,9 @@
     added more sequences;
     don't add a newline immediately after a wrap;
     restore cursor visibility on unload.
+
+  v1.71, 22 October 2015:
+    Add macro definition to wrap wcstok.
 */
 
 #include "ansicon.h"
@@ -138,6 +141,17 @@
 #include <tlhelp32.h>
 
 #define is_digit(c) ('0' <= (c) && (c) <= '9')
+
+// Wrapper for wcstok
+#ifdef _MSC_VER
+#  if _MSC_VER < 1900
+#    define WCSTOK(str, del, ptr) wcstok((str), (del))
+#  else
+#    define WCSTOK wcstok
+#  endif
+#else
+#  define WCSTOK wcstok
+#endif
 
 // ========== Global variables and constants
 
@@ -369,6 +383,7 @@ BOOL search_env( LPCTSTR var, LPCTSTR val )
   static DWORD	env_len;
   DWORD len;
   BOOL	not;
+  LPTSTR *pContext = NULL;
 
   len = GetEnvironmentVariable( var, env, env_len );
   if (len == 0)
@@ -388,7 +403,7 @@ BOOL search_env( LPCTSTR var, LPCTSTR val )
   if (not && env[1] == '\0')
     return TRUE;
 
-  for (var = wcstok( env + not, L";" ); var; var = wcstok( NULL, L";" ))
+  for (var = WCSTOK( env + not, L";", pContext); var; var = WCSTOK( NULL, L";", pContext))
     if (_wcsicmp( val, var ) == 0)
       return !not;
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 
 			 Copyright 2005-2014 Jason Hood
 
-			    Version 1.70.  Freeware
+			    Version 1.71.  Freeware
 
 
 Description
@@ -290,6 +290,9 @@ Version History
 ===============
 
     Legend: + added, - bug-fixed, * changed.
+    
+    1.71 - 22 October, 2015:
+    + add macro definition to wrap wcstok.
 
     1.70 - 26 February, 2014:
     - don't hook again if using LoadLibrary or LoadLibraryEx;

--- a/version.h
+++ b/version.h
@@ -2,11 +2,11 @@
   version.h - Version defines.
 */
 
-#define PVERS	L"1.70"         // wide string
-#define PVERSA	 "1.70"         // ANSI string (windres 2.16.91 didn't like L)
-#define PVERE	L"170"          // wide environment string
-#define PVEREA	 "170"          // ANSI environment string
-#define PVERB	1,7,0,0 	// binary (resource)
+#define PVERS	L"1.71"         // wide string
+#define PVERSA	 "1.71"         // ANSI string (windres 2.16.91 didn't like L)
+#define PVERE	L"171"          // wide environment string
+#define PVEREA	 "171"          // ANSI environment string
+#define PVERB	1,7,1,0 	// binary (resource)
 
 #ifdef _WIN64
 # define BITS L"64"


### PR DESCRIPTION
MSVC version 19 introduces a few breaking changes to the standard C library ([reference](https://msdn.microsoft.com/en-us/library/bb531344(v=vs.140).aspx)), including changing the signature of `wcstok` to match standard implementations.

Here, I have wrapped `wcstok` with a macro that discards the third parameter when compiled with older versions of the library.
