### PR TITLE
Add _CRT_NON_CONFORMING_WCSTOK define

### DIFF
--- a/ANSI.c
+++ b/ANSI.c
@@ -131,7 +131,12 @@
     added more sequences;
     don't add a newline immediately after a wrap;
     restore cursor visibility on unload.
+
+  v1.71, 23 October, 2015
+    Add _CRT_NON_CONFORMING_WCSTOK define
 */
+
+#define _CRT_NON_CONFORMING_WCSTOK
 
 #include "ansicon.h"
 #include "version.h"

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 
 			 Copyright 2005-2014 Jason Hood
 
-			    Version 1.70.  Freeware
+			    Version 1.71.  Freeware
 
 
 Description
@@ -290,6 +290,9 @@ Version History
 ===============
 
     Legend: + added, - bug-fixed, * changed.
+
+    1.71 - 23 October, 2015:
+    + add _CRT_NON_CONFORMING_WCSTOK define
 
     1.70 - 26 February, 2014:
     - don't hook again if using LoadLibrary or LoadLibraryEx;

--- a/version.h
+++ b/version.h
@@ -2,11 +2,11 @@
   version.h - Version defines.
 */
 
-#define PVERS	L"1.70"         // wide string
-#define PVERSA	 "1.70"         // ANSI string (windres 2.16.91 didn't like L)
-#define PVERE	L"170"          // wide environment string
-#define PVEREA	 "170"          // ANSI environment string
-#define PVERB	1,7,0,0 	// binary (resource)
+#define PVERS	L"1.71"         // wide string
+#define PVERSA	 "1.71"         // ANSI string (windres 2.16.91 didn't like L)
+#define PVERE	L"171"          // wide environment string
+#define PVEREA	 "171"          // ANSI environment string
+#define PVERB	1,7,1,0 	// binary (resource)
 
 #ifdef _WIN64
 # define BITS L"64"


### PR DESCRIPTION
MSVC version 19 introduces a few breaking changes to the standard C library ([reference](https://msdn.microsoft.com/en-us/library/bb531344.aspx)), including changing the signature of wcstok to match standard implementations.

Adding `#define _CRT_NON_CONFORMING_WCSTOK` before including `ansicon.h` seems to fix the problem.